### PR TITLE
add encoders module : msf > set ruby/base32 

### DIFF
--- a/modules/encoders/ruby/base32.rb
+++ b/modules/encoders/ruby/base32.rb
@@ -1,0 +1,33 @@
+ This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder
+  Rank = GreatRanking
+
+  def initialize
+    super(
+      'Name'             => 'Ruby Base32 Encoder',
+      'Description'      => %q{
+        This encoder returns a Base32 string encapsulated in
+        eval(%(Base32 encoded string).unpack(%(m0)).first).
+      },
+      'Author'           => 'Ismail Tasdelen',
+      'License'          => BSD_LICENSE,
+      'Arch'             => ARCH_RUBY)
+  end
+
+  def encode_block(state, buf)
+    %w{( ) . % e v a l u n p c k m 0 f i r s t}.each do |c|
+      raise BadcharError if state.badchars.include?(c)
+    end
+
+    Base32 = Rex::Text.encode_Base32(buf)
+
+    state.badchars.each_byte do |byte|
+      raise BadcharError if Base32.include?(byte.chr)
+    end
+
+    return "eval(%(" + Base32 + ").unpack(%(m0)).first)"
+  end
+end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_eternalblue`
- [x] `show encoders`
- [x] `set ruby/base32`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

